### PR TITLE
Update apache-flex-spelling-framework.pom

### DIFF
--- a/Squiggly/main/maven/apache-flex-spelling-framework.pom
+++ b/Squiggly/main/maven/apache-flex-spelling-framework.pom
@@ -18,7 +18,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flex.squiggly</groupId>
-            <artifactId>apache-flex-linguistic-utils</artifactId>
+            <artifactId>apache-flex-spelling-linguistic-utils</artifactId>
             <version>@VERSION@</version>
             <type>swc</type>
         </dependency>


### PR DESCRIPTION
Misspelling of apache-flex-linguistic-utils instead of apache-flex-spelling-linguistic-utils
