### PR TITLE
AntOnAIR: specifies swf-version 23 when building SWC and test SWF

### DIFF
--- a/ant_on_air/build.xml
+++ b/ant_on_air/build.xml
@@ -128,6 +128,7 @@
         description="Compiles the SWC.">
         <compc 
             output="${LIBRARY_DIR}/${LIBRARY_NAME}.swc"
+			swf-version="23"
             debug="${DEBUG_FLAG}"
             failonerror="true"
             fork="true"
@@ -158,6 +159,7 @@
 		<mxmlc file="${basedir}/tests/AntOnAir.mxml"
 			output="${basedir}/tests/AntOnAir.swf"
 			debug="${DEBUG_FLAG}"
+			swf-version="23"
 			failonerror="true"
             fork="true"
             maxmemory="512m">


### PR DESCRIPTION
This matches the 4.0 AIR descriptor used in the tests. When using an SDK newer than 4.0, AIR would quit with 'error while loading initial content' when running the tests because the newer SDK would build with a higher swf-version than 23 by default, so it wouldn't be compatible with the 4.0 AIR descriptor.