### PR TITLE
AntOnAIR: added support for <replacetoken> and <replacevalue> tags

### DIFF
--- a/ant_on_air/src/org/apache/flex/ant/tags/Replace.as
+++ b/ant_on_air/src/org/apache/flex/ant/tags/Replace.as
@@ -26,6 +26,7 @@ package org.apache.flex.ant.tags
     
     import org.apache.flex.ant.Ant;
     import org.apache.flex.ant.tags.supportClasses.TaskHandler;
+    import org.apache.flex.xml.ITagHandler;
     
     [Mixin]
     public class Replace extends TaskHandler
@@ -89,10 +90,26 @@ package org.apache.flex.ant.tags
             {
                 for (var i:int = 0; i < numChildren; i++)
                 {
-                    var rf:ReplaceFilter = getChildAt(i) as ReplaceFilter;
-                    rf.setContext(context);
-                    tokens.push(rf.token);
-                    reps.push(rf.value);
+                    var child:ITagHandler = getChildAt(i);
+                    if(child is ReplaceFilter)
+                    {
+                        var rf:ReplaceFilter = child as ReplaceFilter;
+                        rf.setContext(context);
+                        tokens.push(rf.token);
+                        reps.push(rf.value);
+                    }
+                    else if(child is ReplaceToken)
+                    {
+                        var rt:ReplaceToken = child as ReplaceToken;
+                        rt.setContext(context);
+                        tokens.push(rt.text);
+                    }
+                    else if(child is ReplaceValue)
+                    {
+                        var rv:ReplaceValue = child as ReplaceValue;
+                        rv.setContext(context);
+                        reps.push(rv.text);
+                    }
                 }
             }
             var n:int = tokens.length;

--- a/ant_on_air/src/org/apache/flex/ant/tags/ReplaceToken.as
+++ b/ant_on_air/src/org/apache/flex/ant/tags/ReplaceToken.as
@@ -1,0 +1,44 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package org.apache.flex.ant.tags
+{
+	import mx.core.IFlexModuleFactory;
+	
+	import org.apache.flex.ant.Ant;
+	import org.apache.flex.ant.tags.supportClasses.TagHandler;
+	
+	[Mixin]
+	public class ReplaceToken extends TagHandler
+	{
+		public static function init(mf:IFlexModuleFactory):void
+		{
+			Ant.antTagProcessors["replacetoken"] = ReplaceToken;
+		}
+
+		public function ReplaceToken()
+		{
+			super();
+		}
+		
+		public function get text():String
+		{
+			return ant.getValue(xml.text().toString(), context);
+		}
+	}
+}

--- a/ant_on_air/src/org/apache/flex/ant/tags/ReplaceValue.as
+++ b/ant_on_air/src/org/apache/flex/ant/tags/ReplaceValue.as
@@ -1,0 +1,44 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+//  Licensed to the Apache Software Foundation (ASF) under one or more
+//  contributor license agreements.  See the NOTICE file distributed with
+//  this work for additional information regarding copyright ownership.
+//  The ASF licenses this file to You under the Apache License, Version 2.0
+//  (the "License"); you may not use this file except in compliance with
+//  the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+package org.apache.flex.ant.tags
+{
+	import mx.core.IFlexModuleFactory;
+	
+	import org.apache.flex.ant.Ant;
+	import org.apache.flex.ant.tags.supportClasses.TagHandler;
+	
+	[Mixin]
+	public class ReplaceValue extends TagHandler
+	{
+		public static function init(mf:IFlexModuleFactory):void
+		{
+			Ant.antTagProcessors["replacevalue"] = ReplaceValue;
+		}
+
+		public function ReplaceValue()
+		{
+			super();
+		}
+		
+		public function get text():String
+		{
+			return ant.getValue(xml.text().toString(), context);
+		}
+	}
+}

--- a/ant_on_air/tests/test.xml
+++ b/ant_on_air/tests/test.xml
@@ -186,6 +186,7 @@
             <entry key="somekey" value="somevalue" />
             <entry key="somekey1" value="somevalue1" />
             <entry key="looptest" value="foo" />
+            <entry key="xml" value="&lt;test/&gt;" />
         </propertyfile>
         <fail message="propertyfile did not result in expected file">
             <condition>
@@ -198,6 +199,14 @@
         <replace file="${basedir}/temp/custom.properties" token="foo" value="food" />
         <replace file="${basedir}/temp/custom.properties">
             <replacefilter token="key" value="ky" />
+        </replace>
+        <replace file="${basedir}/temp/custom.properties">
+            <replacetoken>loop</replacetoken>
+            <replacevalue>lop</replacevalue>
+        </replace>
+        <replace file="${basedir}/temp/custom.properties">
+            <replacetoken><![CDATA[<test/>]]></replacetoken>
+            <replacevalue><![CDATA[<cdata/>]]></replacevalue>
         </replace>
         <loadproperties srcFile="${basedir}/temp/custom.properties" />
         <fail message="replace did not work: found somekey">
@@ -212,6 +221,11 @@
                 </not>
             </condition>
         </fail>
+        <fail message="replace did not work: found looptest">
+            <condition>
+                <isset property="looptest" />
+            </condition>
+        </fail>
         <fail message="replace did not work: did not find replacedkey1">
             <condition>
                 <not>
@@ -222,7 +236,14 @@
         <fail message="replace did not work: did not find food">
             <condition>
                 <not>
-                    <equals arg1="${looptest}" arg2="food" />
+                    <equals arg1="${loptest}" arg2="food" />
+                </not>
+            </condition>
+        </fail>
+        <fail message="replace did not work: did not find &lt;cdata/&gt;">
+            <condition>
+                <not>
+                    <equals arg1="${xml}" arg2="&lt;cdata/&gt;" />
                 </not>
             </condition>
         </fail>


### PR DESCRIPTION
These tags may be added as children of the <replace> tag, similar to <replacefilter>. They make it possible to use CDATA and new lines in tokens and values.