### PR TITLE
Correctly locate SCRIPT_HOME even when scripts are invoked from symli…

### DIFF
--- a/npm-flexjs/js/bin/asjscnpm
+++ b/npm-flexjs/js/bin/asjscnpm
@@ -25,7 +25,8 @@
 # In Windows Command Prompt, use mxmlc.bat instead.
 #
 
-SCRIPT_HOME=`dirname $0`
+SCRIPT_REAL_PATH=`readlink -f "$0"`
+SCRIPT_HOME=`dirname "$SCRIPT_REAL_PATH"`
 FALCON_HOME=${SCRIPT_HOME}/../..
 FLEX_HOME=${SCRIPT_HOME}/../..
 
@@ -53,9 +54,6 @@ elif [ $OS = "Unix" ]; then
     if [ "$isOSX" != "" -a "$HOSTTYPE" = "x86_64" -a "$check64" != "" -a "$javaVersion" = "1.6" ]; then
         D32='-d32'
     fi
-    FALCON_HOME="/usr/local/lib/node_modules/flexjs"
-    FLEX_HOME="/usr/local/lib/node_modules/flexjs"
-    SCRIPT_HOME="/usr/local/lib/node_modules/flexjs/js/bin"
 fi
 
 VMARGS="-Xmx384m -Dsun.io.useCanonCaches=false "

--- a/npm-flexjs/js/bin/asjscnpm
+++ b/npm-flexjs/js/bin/asjscnpm
@@ -25,8 +25,10 @@
 # In Windows Command Prompt, use mxmlc.bat instead.
 #
 
-SCRIPT_REAL_PATH=`readlink -f "$0"`
-SCRIPT_HOME=`dirname "$SCRIPT_REAL_PATH"`
+function abspath() { pushd . > /dev/null; if [ -d "$1" ]; then cd "$1"; dirs -l +0; else cd "`dirname \"$1\"`"; cur_dir=`dirs -l +0`; if [ "$cur_dir" == "/" ]; then echo "$cur_dir`basename \"$1\"`"; else echo "$cur_dir/`basename \"$1\"`"; fi; fi; popd > /dev/null; }
+SCRIPT_REAL_FILE=`readlink "$0" || echo "$0"`;
+SCRIPT_ABS_PATH=`abspath "$SCRIPT_REAL_FILE"`
+SCRIPT_HOME=`dirname "$SCRIPT_ABS_PATH"`
 FALCON_HOME=${SCRIPT_HOME}/../..
 FLEX_HOME=${SCRIPT_HOME}/../..
 

--- a/npm-flexjs/js/bin/asjscompcnpm
+++ b/npm-flexjs/js/bin/asjscompcnpm
@@ -25,8 +25,10 @@
 # In Windows Command Prompt, use mxmlc.bat instead.
 #
 
-SCRIPT_REAL_PATH=`readlink -f "$0"`
-SCRIPT_HOME=`dirname "$SCRIPT_REAL_PATH"`
+function abspath() { pushd . > /dev/null; if [ -d "$1" ]; then cd "$1"; dirs -l +0; else cd "`dirname \"$1\"`"; cur_dir=`dirs -l +0`; if [ "$cur_dir" == "/" ]; then echo "$cur_dir`basename \"$1\"`"; else echo "$cur_dir/`basename \"$1\"`"; fi; fi; popd > /dev/null; }
+SCRIPT_REAL_FILE=`readlink "$0" || echo "$0"`;
+SCRIPT_ABS_PATH=`abspath "$SCRIPT_REAL_FILE"`
+SCRIPT_HOME=`dirname "$SCRIPT_ABS_PATH"`
 FALCON_HOME=${SCRIPT_HOME}/../..
 FLEX_HOME=${SCRIPT_HOME}/../..
 

--- a/npm-flexjs/js/bin/mxmlcnpm
+++ b/npm-flexjs/js/bin/mxmlcnpm
@@ -25,8 +25,10 @@
 # In Windows Command Prompt, use mxmlc.bat instead.
 #
 
-SCRIPT_REAL_PATH=`readlink -f "$0"`
-SCRIPT_HOME=`dirname "$SCRIPT_REAL_PATH"`
+function abspath() { pushd . > /dev/null; if [ -d "$1" ]; then cd "$1"; dirs -l +0; else cd "`dirname \"$1\"`"; cur_dir=`dirs -l +0`; if [ "$cur_dir" == "/" ]; then echo "$cur_dir`basename \"$1\"`"; else echo "$cur_dir/`basename \"$1\"`"; fi; fi; popd > /dev/null; }
+SCRIPT_REAL_FILE=`readlink "$0" || echo "$0"`;
+SCRIPT_ABS_PATH=`abspath "$SCRIPT_REAL_FILE"`
+SCRIPT_HOME=`dirname "$SCRIPT_ABS_PATH"`
 if [ "x${FALCON_HOME}" = "x" ]
 then
     FALCON_HOME=${SCRIPT_HOME}/../..

--- a/npm-flexjs/js/bin/mxmlcnpm
+++ b/npm-flexjs/js/bin/mxmlcnpm
@@ -27,8 +27,18 @@
 
 SCRIPT_REAL_PATH=`readlink -f "$0"`
 SCRIPT_HOME=`dirname "$SCRIPT_REAL_PATH"`
-FALCON_HOME=${SCRIPT_HOME}/../..
-FLEX_HOME=${SCRIPT_HOME}/../..
+if [ "x${FALCON_HOME}" = "x" ]
+then
+    FALCON_HOME=${SCRIPT_HOME}/../..
+fi
+
+echo Using Falcon codebase: $FALCON_HOME
+
+if [ "x${FLEX_HOME}" = "x" ]
+then
+    FLEX_HOME=${SCRIPT_HOME}/../..
+fi
+echo Using Flex SDK: $FLEX_HOME
 
 case `uname` in
 		CYGWIN*)
@@ -50,12 +60,12 @@ elif [ $OS = "Unix" ]; then
     check64="`java -version 2>&1 | grep -i 64-Bit`"
     isOSX="`uname | grep -i Darwin`"
     javaVersion="`java -version 2>&1 | awk -F '[ ".]+' 'NR==1 {print $3 "." $4}'`"
-
+    
     if [ "$isOSX" != "" -a "$HOSTTYPE" = "x86_64" -a "$check64" != "" -a "$javaVersion" = "1.6" ]; then
         D32='-d32'
-    fi
+    fi	
 fi
 
 VMARGS="-Xmx384m -Dsun.io.useCanonCaches=false "
 
-java $VMARGS $D32 $SETUP_SH_VMARGS -Dflexcompiler="$FALCON_HOME" -Dflexlib="$FLEX_HOME/frameworks" -jar "$SCRIPT_HOME/../lib/compc.jar" +flexlib="$FLEX_HOME/frameworks" -js-output-type=jsc -external-library-path="$SCRIPT_HOME/../libs/js.swc" "$@"
+java $VMARGS $D32 $SETUP_SH_VMARGS -Dflexcompiler="$FALCON_HOME" -Dflexlib="$FLEX_HOME/frameworks" -jar "$SCRIPT_HOME/../lib/mxmlc.jar" +flexlib="$FLEX_HOME/frameworks" -js-output-type=FLEXJS -sdk-js-lib="$FLEX_HOME/frameworks/js/FlexJS/src" "$@"


### PR DESCRIPTION
…nk; add mxmlcnpm

This will enable non-global installs of the flexjs npm module to work on Linux, OSX, and Cygwin. It removes the hardcoded /usr/local paths, and ensures that if the compiler is invoked from the node_modules/.bin/ symlink that the correct home path is found.
